### PR TITLE
Please pull to fix bug for virgin hashes

### DIFF
--- a/lib/xmlsimple.rb
+++ b/lib/xmlsimple.rb
@@ -800,9 +800,12 @@ class XmlSimple
           end
 
           # Check for the '@' attribute prefix to allow separation of attributes and elements
-          if @options['noattr'] ||
-             (@options['attrprefix'] && !(key =~ /^@(.*)/)) ||
-             !scalar(value)
+             
+          if (@options['noattr'] ||
+              (@options['attrprefix'] && !(key =~ /^@(.*)/)) ||
+              !scalar(value)
+             ) &&
+             key != @options['contentkey']
             nested << value_to_xml(value, key, indent + @options['indent'])
           else
             value = value.to_s


### PR DESCRIPTION
When calling xml_out for hashes not produced using xml_in, the content keys are never converted to text_content, so you end up with:

```
<opt>
  <item name="one">
    <content>First</content>
  </item>
  <item name="two">
    <content>Second</content>
  </item>
<opt>
```

rather than:

```
<opt>
  <item name="one">First</item>
  <item name="two">Second</item>
<opt>
```

This patch fixes with no apparent side-effects, unless you can see any?
