### PR TITLE
Fix the homepage reference.

### DIFF
--- a/xml-simple.gemspec
+++ b/xml-simple.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.date = %q{2011-10-11}
   s.summary = %q{A simple API for XML processing.}
   s.email = %q{contact@maik-schmidt.de}
-  s.homepage = %q{http://xml-simple.rubyforge.org}
+  s.homepage = %q{https://github.com/maik/xml-simple}
   s.rubyforge_project = %q{xml-simple}
   s.authors = ["Maik Schmidt"]
   s.files = ["lib/xmlsimple.rb"]


### PR DESCRIPTION
I don't know where to change/remove the "Rubyforge" reference shown in `gem query --details --all --remote --name-matches xml-simple`
