### PR TITLE
Convert kebob-case to snake-case in attribute names

### DIFF
--- a/lib/xmlsimple.rb
+++ b/lib/xmlsimple.rb
@@ -267,7 +267,7 @@ class XmlSimple
       keyattr keeproot forcecontent contentkey noattr searchpath
       forcearray suppressempty anonymoustag cache grouptags
       normalisespace normalizespace variables varattr keytosymbol
-      attrtosymbol attrprefix conversions kabobtosnakecase
+      attrtosymbol attrprefix conversions kebabtosnakecase
     ),
     'out' => %w(
       keyattr keeproot contentkey noattr rootname
@@ -286,7 +286,7 @@ class XmlSimple
   DEF_INDENTATION     = '  '
   DEF_KEY_TO_SYMBOL   = false
   DEF_ATTR_TO_SYMBOL  = false
-  DEF_KABOB_TO_SNAKE  = false
+  DEF_KEBAB_TO_SNAKE  = false
 
   # Normalizes option names in a hash, i.e., turns all
   # characters to lower case and removes all underscores.
@@ -456,7 +456,7 @@ class XmlSimple
       @_var_values = {}
     end
 
-    @options['kabobtosnakecase'] = DEF_KABOB_TO_SNAKE unless @options.has_key?('kabobtosnakecase')
+    @options['kebabtosnakecase'] = DEF_KEBAB_TO_SNAKE unless @options.has_key?('kebabtosnakecase')
   end
 
   # Actually converts an XML document element into a data structure.
@@ -495,10 +495,10 @@ class XmlSimple
     if @options.has_key?('grouptags')
       result.each { |key, value|
         # In results, key should already be converted
-        raise("Unconverted key '#{key}' found. Should be '#{kabob_to_snake_case key}'.") if (key != kabob_to_snake_case(key))
+        raise("Unconverted key '#{key}' found. Should be '#{kebab_to_snake_case key}'.") if (key != kebab_to_snake_case(key))
         next unless (value.is_a?(Hash) && (value.size == 1))
         child_key, child_value = value.to_a[0]
-        child_key = kabob_to_snake_case child_key # todo test whether necessary
+        child_key = kebab_to_snake_case child_key # todo test whether necessary
         if @options['grouptags'][key] == child_key
           result[key] = child_value
         end
@@ -554,7 +554,7 @@ class XmlSimple
     keyattr = @options['keyattr']
     if (keyattr.is_a?(Array) || keyattr.is_a?(Hash))
       hash.each { |key, value|
-        key = kabob_to_snake_case key
+        key = kebab_to_snake_case key
         if value.is_a?(Array)
           if keyattr.is_a?(Array)
             hash[key] = fold_array(value)
@@ -651,7 +651,7 @@ class XmlSimple
   # value::
   #   Value to be associated with key.
   def merge(hash, key, value)
-    key = kabob_to_snake_case key
+    key = kebab_to_snake_case key
     if value.is_a?(String)
       value = normalise_space(value) if @options['normalisespace'] == 2
 
@@ -666,7 +666,7 @@ class XmlSimple
 
       # look for variable definitions
       if @options.has_key?('varattr')
-        varattr = kabob_to_snake_case @options['varattr']
+        varattr = kebab_to_snake_case @options['varattr']
         if hash.has_key?(varattr)
           set_var(hash[varattr], value)
         end
@@ -720,12 +720,12 @@ class XmlSimple
   def get_attributes(node)
     attributes = {}
     if @options['attrprefix']
-      node.attributes.each { |n,v| attributes["@" + kabob_to_snake_case(n)] = v }
+      node.attributes.each { |n,v| attributes["@" + kebab_to_snake_case(n)] = v }
     elsif @options.has_key?('attrtosymbol') and @options['attrtosymbol'] == true
       #patch for converting attribute names to symbols
-      node.attributes.each { |n,v| attributes[kabob_to_snake_case(n).to_sym] = v }
+      node.attributes.each { |n,v| attributes[kebab_to_snake_case(n).to_sym] = v }
     else
-      node.attributes.each { |n,v| attributes[kabob_to_snake_case(n)] = v }
+      node.attributes.each { |n,v| attributes[kebab_to_snake_case(n)] = v }
     end
 
     attributes
@@ -1044,13 +1044,13 @@ class XmlSimple
     end
   end
 
-  # Substitutes underscores for hyphens if the KabobToSnakeCase option is selected. For when you don't
+  # Substitutes underscores for hyphens if the KebabToSnakeCase option is selected. For when you don't
   # want to refer to keys by hash[:'my-key'] but instead as hash[:my_key]
   #
   # key::
   #   Key to be converted.
-  def kabob_to_snake_case(key)
-    return key unless (@options['kabobtosnakecase'])
+  def kebab_to_snake_case(key)
+    return key unless (@options['kebabtosnakecase'])
 
     is_symbol = key.is_a? Symbol
     key = key.to_s.gsub(/-/, '_')


### PR DESCRIPTION
We made this change to meet a requirement in an application. I feel that it could be useful for others who are ingesting XML that's out of their control.