### PR TITLE
Distribute under the MIT license 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2003-2020 Maik Schmidt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -16,13 +16,4 @@ See INSTALL.
 ## License
 
 XmlSimple is Copyright (c) 2003-2020 Maik Schmidt. It is free software,
-and may be redistributed under the terms specified in the COPYING file
-of the current Ruby distribution.
-
-## Warranty
-
-This software is provided "as is" and without any express or
-implied warranties, including, without limitation, the implied
-warranties of merchantability and fitness for a particular
-purpose.
-
+and may be redistributed under the terms specified in the LICENSE file.

--- a/xml-simple.gemspec
+++ b/xml-simple.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.summary = %q{A simple API for XML processing.}
   s.email = %q{contact@maik-schmidt.de}
   s.homepage = %q{https://github.com/maik/xml-simple}
-  s.license = "Ruby"
+  s.license = "MIT"
   s.authors = ["Maik Schmidt"]
   s.files = ["lib/xmlsimple.rb"]
 end


### PR DESCRIPTION
Hi! I hope you'll considering re-licensing this project.

MIT is the most commonly used license in the Ruby community. The Ruby license is not recognised by the Open Source Initiative as an open-source license because it is so obscure. Licensing as MIT makes your users lives easier in ensuring their license compliance; it's likely they have many other MIT-licensed dependencies and 0 other Ruby-licensed dependencies.