### PR TITLE
Add an option for self-closing tags

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -877,6 +877,11 @@ p result
       <em>Note:</em> the current directory ('.') is not searched unless it is the
       directory containing the script.
       </p>
+      <h3>SelfClose =&gt; true | false (out)</h3>
+      <p>
+      If set, <em>xml_out</em> will use self-closing tags for empty elements.
+      For example: <pre>&lt;element /&gt;</pre> instead of <pre>&lt;element&gt;&lt;/element&gt;</pre>
+      </p>
       <h3>SuppressEmpty =&gt; true | '' | nil (in + out) (handy)</h3>
       <p>
       This option controls what <em>xml_in</em> should do with empty elements

--- a/lib/xmlsimple.rb
+++ b/lib/xmlsimple.rb
@@ -272,7 +272,7 @@ class XmlSimple
     'out' => %w(
       keyattr keeproot contentkey noattr rootname
       xmldeclaration outputfile noescape suppressempty
-      anonymoustag indent grouptags noindent attrprefix
+      anonymoustag indent grouptags noindent attrprefix selfclose
     )
   }
 
@@ -835,7 +835,7 @@ class XmlSimple
             end
           end
         }
-      else
+      elsif !@options['selfclose']
         text_content = ''
       end
 

--- a/test/tc_out.rb
+++ b/test/tc_out.rb
@@ -156,6 +156,27 @@ END_OF_XML
     assert_equal(expected, XmlSimple.xml_out(hash))
   end
 
+  def test_selfclose
+    hash = {
+      'root' => [
+        {
+          'empty' => ['text', {}, {}]
+        }
+      ]
+    }
+    expected = <<"END_OF_XML"
+<opt>
+  <root>
+    <empty>text</empty>
+    <empty />
+    <empty />
+  </root>
+</opt>
+END_OF_XML
+
+    assert_equal(expected, XmlSimple.xml_out(hash, 'selfclose' => true))
+  end
+
   def test_output_with_symbols
     test1 = { :foo => 'abc' }
     expected = "<opt foo=\"abc\" />\n"


### PR DESCRIPTION
Use `<tag />` instead of `<tag></tag>`