### PR TITLE
Add `rexml` dependency

### DIFF
--- a/xml-simple.gemspec
+++ b/xml-simple.gemspec
@@ -8,4 +8,5 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.authors = ["Maik Schmidt"]
   s.files = ["lib/xmlsimple.rb"]
+  s.add_runtime_dependency "rexml" 
 end


### PR DESCRIPTION
as it's required in `lib/xmlsimple.rb`.

This is needed for compatibility with Ruby 3.0.